### PR TITLE
wiki/pacman.md: explicitly state the config file

### DIFF
--- a/wiki/pacman.md
+++ b/wiki/pacman.md
@@ -1,6 +1,6 @@
 ## Pacman++
 
-These are a few pacman options worth checking in `/etc/pacman.conf`:
+These are a few pacman options worth checking out in `/etc/pacman.conf`:
 
 ##### Colored output:
 Uncomment `#Color` in the `# Misc options` section for a colorful pacman experience.

--- a/wiki/pacman.md
+++ b/wiki/pacman.md
@@ -1,5 +1,7 @@
 ## Pacman++
 
+These are a few pacman options worth checking in `/etc/pacman.conf`:
+
 ##### Colored output:
 Uncomment `#Color` in the `# Misc options` section for a colorful pacman experience.
 


### PR DESCRIPTION
The wiki page describes a few config options without specifying which file they are in. This should be addressed.